### PR TITLE
iso3166.yml: MK name change

### DIFF
--- a/_data/iso3166.yml
+++ b/_data/iso3166.yml
@@ -431,7 +431,7 @@ MH:
   name: Marshall Islands
   emoji: 🇲🇭
 MK:
-  name: Macedonia, the former Yugoslav Republic of
+  name: North Macedonia, Republic of
   emoji: 🇲🇰
 ML:
   name: Mali


### PR DESCRIPTION
now North Macedonia, Republic of was Macedonia, the Former Yugoslav Republic of